### PR TITLE
Fix issue with unlimited memory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
 
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/tech/goksi/pterobot/util/MemoryBar.kt
+++ b/src/main/kotlin/tech/goksi/pterobot/util/MemoryBar.kt
@@ -7,15 +7,23 @@ data class MemoryBar(val usedMemory: Long, val maxMemory: Long) {
 
     override fun toString(): String {
         val builder = StringBuilder()
-        val oneBlock = (maxMemory / 10).toInt()
-        val numberOfFull = (usedMemory / oneBlock).toInt()
-
-        for (i in 1..10) {
-            if (i <= numberOfFull) {
-                builder.append(FULL_CHAR)
-            } else {
+        if(maxMemory < 1) {
+            builder.append(FULL_CHAR)
+            for (i in 1..9) {
                 builder.append(EMPTY_CHAR)
             }
+        } else {
+            val oneBlock = (maxMemory / 10).toInt()
+            val numberOfFull = (usedMemory / oneBlock).toInt()
+
+            for (i in 1..10) {
+                if (i <= numberOfFull) {
+                    builder.append(FULL_CHAR)
+                } else {
+                    builder.append(EMPTY_CHAR)
+                }
+            }
+
         }
         return builder.toString()
     }


### PR DESCRIPTION
When the api returned 0 as the maximum memory, an ArithmeticException was thrown.