### PR TITLE
Fixing bunch of empty lines in logs file

### DIFF
--- a/src/main/kotlin/tech/goksi/pterobot/util/Common.kt
+++ b/src/main/kotlin/tech/goksi/pterobot/util/Common.kt
@@ -4,6 +4,8 @@ import com.mattmalec.pterodactyl4j.PteroBuilder
 import com.mattmalec.pterodactyl4j.application.entities.PteroApplication
 import com.mattmalec.pterodactyl4j.client.entities.ClientServer
 import com.mattmalec.pterodactyl4j.client.entities.PteroClient
+import com.mattmalec.pterodactyl4j.client.ws.events.output.ConsoleOutputEvent
+import com.mattmalec.pterodactyl4j.client.ws.events.output.DaemonMessageEvent
 import dev.minn.jda.ktx.util.SLF4J
 import kotlinx.coroutines.*
 import tech.goksi.pterobot.events.handlers.PteroEventManager
@@ -54,7 +56,7 @@ object Common {
         val stringBuilder = StringBuilder()
         val wssBuilder = this.webSocketBuilder
         val task = (wssBuilder.eventManager as PteroEventManager).websocketListener {
-            stringBuilder.append(it.line).append('\n')
+            stringBuilder.append(it.line)
         }
         val wss = wssBuilder.addEventListeners(task).build()
         delay(task.expireAfter)

--- a/src/main/kotlin/tech/goksi/pterobot/util/Common.kt
+++ b/src/main/kotlin/tech/goksi/pterobot/util/Common.kt
@@ -4,8 +4,6 @@ import com.mattmalec.pterodactyl4j.PteroBuilder
 import com.mattmalec.pterodactyl4j.application.entities.PteroApplication
 import com.mattmalec.pterodactyl4j.client.entities.ClientServer
 import com.mattmalec.pterodactyl4j.client.entities.PteroClient
-import com.mattmalec.pterodactyl4j.client.ws.events.output.ConsoleOutputEvent
-import com.mattmalec.pterodactyl4j.client.ws.events.output.DaemonMessageEvent
 import dev.minn.jda.ktx.util.SLF4J
 import kotlinx.coroutines.*
 import tech.goksi.pterobot.events.handlers.PteroEventManager
@@ -56,7 +54,10 @@ object Common {
         val stringBuilder = StringBuilder()
         val wssBuilder = this.webSocketBuilder
         val task = (wssBuilder.eventManager as PteroEventManager).websocketListener {
-            stringBuilder.append(it.line)
+            val line = it.line
+            if (line.isEmpty()) return@websocketListener
+            if (!line.contains('\r') && stringBuilder.isNotEmpty()) stringBuilder.append('\n')
+            stringBuilder.append(line)
         }
         val wss = wssBuilder.addEventListeners(task).build()
         delay(task.expireAfter)


### PR DESCRIPTION
Not sure if this is Minecraft specific that pterodactyl appends `\r` at the beginning of console output event, but it works ig